### PR TITLE
feat: add context-sensitive hash tag escaping

### DIFF
--- a/src/content-generator.ts
+++ b/src/content-generator.ts
@@ -22,6 +22,9 @@ export class ContentGenerator {
 		comments: any[],
 		settings: GitHubTrackerSettings,
 	): Promise<string> {
+		// Determine whether to escape hash tags (repo setting takes precedence if ignoreGlobalSettings is true)
+		const shouldEscapeHashTags = repo.ignoreGlobalSettings ? repo.escapeHashTags : settings.escapeHashTags;
+
 		// Check if custom template is enabled and load template content
 		if (repo.useCustomIssueContentTemplate && repo.issueContentTemplate) {
 			const templateContent = await this.fileHelpers.loadTemplateContent(repo.issueContentTemplate);
@@ -31,7 +34,8 @@ export class ContentGenerator {
 					repo.repository,
 					comments,
 					settings.dateFormat,
-					settings.escapeMode
+					settings.escapeMode,
+					shouldEscapeHashTags
 				);
 				return processContentTemplate(templateContent, templateData, settings.dateFormat);
 			}
@@ -68,14 +72,14 @@ updateMode: "${repo.issueUpdateMode}"
 allowDelete: ${repo.allowDeleteIssue ? true : false}
 ---
 
-# ${escapeBody(issue.title, settings.escapeMode)}
+# ${escapeBody(issue.title, settings.escapeMode, false)}
 ${
 	issue.body
-		? escapeBody(issue.body, settings.escapeMode)
+		? escapeBody(issue.body, settings.escapeMode, shouldEscapeHashTags)
 		: "No description found"
 }
 
-${this.fileHelpers.formatComments(comments, settings.escapeMode, settings.dateFormat)}
+${this.fileHelpers.formatComments(comments, settings.escapeMode, settings.dateFormat, shouldEscapeHashTags)}
 `;
 	}
 
@@ -88,6 +92,9 @@ ${this.fileHelpers.formatComments(comments, settings.escapeMode, settings.dateFo
 		comments: any[],
 		settings: GitHubTrackerSettings,
 	): Promise<string> {
+		// Determine whether to escape hash tags (repo setting takes precedence if ignoreGlobalSettings is true)
+		const shouldEscapeHashTags = repo.ignoreGlobalSettings ? repo.escapeHashTags : settings.escapeHashTags;
+
 		// Check if custom template is enabled and load template content
 		if (repo.useCustomPullRequestContentTemplate && repo.pullRequestContentTemplate) {
 			const templateContent = await this.fileHelpers.loadTemplateContent(repo.pullRequestContentTemplate);
@@ -97,7 +104,8 @@ ${this.fileHelpers.formatComments(comments, settings.escapeMode, settings.dateFo
 					repo.repository,
 					comments,
 					settings.dateFormat,
-					settings.escapeMode
+					settings.escapeMode,
+					shouldEscapeHashTags
 				);
 				return processContentTemplate(templateContent, templateData, settings.dateFormat);
 			}
@@ -139,14 +147,14 @@ updateMode: "${repo.pullRequestUpdateMode}"
 allowDelete: ${repo.allowDeletePullRequest ? true : false}
 ---
 
-# ${escapeBody(pr.title, settings.escapeMode)}
+# ${escapeBody(pr.title, settings.escapeMode, false)}
 ${
 	pr.body
-		? escapeBody(pr.body, settings.escapeMode)
+		? escapeBody(pr.body, settings.escapeMode, shouldEscapeHashTags)
 		: "No description found"
 }
 
-${this.fileHelpers.formatComments(comments, settings.escapeMode, settings.dateFormat)}
+${this.fileHelpers.formatComments(comments, settings.escapeMode, settings.dateFormat, shouldEscapeHashTags)}
 `;
 	}
 }

--- a/src/issue-file-manager.ts
+++ b/src/issue-file-manager.ts
@@ -162,14 +162,16 @@ export class IssueFileManager {
 						this.noticeManager.debug(`Updated issue ${issue.number}`);
 					}
 				} else if (updateMode === "append") {
+					const shouldEscapeHashTags = repo.ignoreGlobalSettings ? repo.escapeHashTags : this.settings.escapeHashTags;
 					content = `---\n### New status: "${
 						issue.state
 					}"\n\n# ${escapeBody(
 						issue.title,
 						this.settings.escapeMode,
+						false,
 					)}\n${
 						issue.body
-							? escapeBody(issue.body, this.settings.escapeMode)
+							? escapeBody(issue.body, this.settings.escapeMode, shouldEscapeHashTags)
 							: "No description found"
 					}\n`;
 
@@ -178,6 +180,7 @@ export class IssueFileManager {
 							comments,
 							this.settings.escapeMode,
 							this.settings.dateFormat,
+							shouldEscapeHashTags,
 						);
 					}
 					const currentFileContent = await this.app.vault.read(file);

--- a/src/pr-file-manager.ts
+++ b/src/pr-file-manager.ts
@@ -164,14 +164,16 @@ export class PullRequestFileManager {
 						this.noticeManager.debug(`Updated PR ${pr.number}`);
 					}
 				} else if (updateMode === "append") {
+					const shouldEscapeHashTags = repo.ignoreGlobalSettings ? repo.escapeHashTags : this.settings.escapeHashTags;
 					content = `---\n### New status: "${
 						pr.state
 					}"\n\n# ${escapeBody(
 						pr.title,
 						this.settings.escapeMode,
+						false,
 					)}\n${
 						pr.body
-							? escapeBody(pr.body, this.settings.escapeMode)
+							? escapeBody(pr.body, this.settings.escapeMode, shouldEscapeHashTags)
 							: "No description found"
 					}\n`;
 					if (comments.length > 0) {
@@ -179,6 +181,7 @@ export class PullRequestFileManager {
 							comments,
 							this.settings.escapeMode,
 							this.settings.dateFormat,
+							shouldEscapeHashTags,
 						);
 					}
 

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -362,6 +362,18 @@ export class GitHubTrackerSettingTab extends PluginSettingTab {
 		escapingContent.createEl("p").textContent = "• Strict: Only allows alphanumeric, '.,'()/[]{}*+-:\"' and whitespace";
 		escapingContent.createEl("p").textContent = "• Very Strict: Only allows alphanumeric, '.,' and whitespace";
 
+		new Setting(advancedContainer)
+			.setName("Escape hash tags")
+			.setDesc("Escape # characters that are not valid Markdown headers to prevent unintended Obsidian tags (e.g., #134 becomes \\#134)")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.escapeHashTags)
+					.onChange(async (value) => {
+						this.plugin.settings.escapeHashTags = value;
+						await this.plugin.saveSettings();
+					}),
+			);
+
 		// Global Defaults Section
 		const globalDefaultsContainer = containerEl.createDiv("github-issues-settings-group");
 		const globalDefaultsHeader = new Setting(globalDefaultsContainer)

--- a/src/settings/repository-list-manager.ts
+++ b/src/settings/repository-list-manager.ts
@@ -370,6 +370,16 @@ export class RepositoryListManager {
 						}),
 					);
 
+				new Setting(detailsContainer)
+					.setName("Escape hash tags")
+					.setDesc("Escape # characters for this repository (overrides global setting if 'Ignore global settings' is enabled)")
+					.addToggle((toggle: any) =>
+						toggle.setValue(repo.escapeHashTags).onChange(async (value: boolean) => {
+							repo.escapeHashTags = value;
+							await this.plugin.saveSettings();
+						}),
+					);
+
 				const issuesContainer = detailsContainer.createDiv(
 					"github-issues-settings-section",
 				);

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export interface RepositoryTracking {
 	includePullRequestComments: boolean;
 	includeClosedIssues: boolean;
 	includeClosedPullRequests: boolean;
+	escapeHashTags: boolean;
 }
 
 export interface GlobalDefaults {
@@ -62,6 +63,7 @@ export interface GitHubTrackerSettings {
 	syncNoticeMode: "minimal" | "normal" | "extensive" | "debug";
 	syncInterval: number;
 	escapeMode: "disabled" | "normal" | "strict" | "veryStrict";
+	escapeHashTags: boolean;
 	enableBackgroundSync: boolean;
 	backgroundSyncInterval: number; // in minutes
 	cleanupClosedIssuesDays: number;
@@ -93,6 +95,7 @@ export const DEFAULT_SETTINGS: GitHubTrackerSettings = {
 	syncNoticeMode: "normal",
 	syncInterval: 0,
 	escapeMode: "strict",
+	escapeHashTags: false,
 	enableBackgroundSync: false,
 	backgroundSyncInterval: 30,
 	cleanupClosedIssuesDays: 30,
@@ -137,4 +140,5 @@ export const DEFAULT_REPOSITORY_TRACKING: RepositoryTracking = {
 	includePullRequestComments: true,
 	includeClosedIssues: false,
 	includeClosedPullRequests: false,
+	escapeHashTags: false,
 };

--- a/src/util/escapeUtils.ts
+++ b/src/util/escapeUtils.ts
@@ -1,7 +1,34 @@
 /**
+ * Escapes # characters that are not valid Markdown headers to prevent
+ * unintended Obsidian tags (e.g., #1337-YesSr becomes \#1337-YesSr)
+ * while preserving valid Markdown headers (# followed by space)
+ * @param text The text to process
+ * @returns The text with escaped # characters
+ */
+function escapeHashTags(text: string): string {
+	const lines = text.split('\n');
+
+	return lines.map(line => {
+		const trimmed = line.trim();
+
+		// Check if this is a valid Markdown header (one or more # followed by a space)
+		// Valid: "# Header", "## Header", "### Header", etc.
+		// Invalid: "#1337", "#tag", "###NoSpace"
+		if (/^#{1,6}\s/.test(trimmed)) {
+			// This is a valid Markdown header, don't escape
+			return line;
+		}
+
+		// Escape all # characters in this line
+		return line.replace(/#/g, '\\#');
+	}).join('\n');
+}
+
+/**
  * Utility function for escaping content in different modes
  * @param unsafe The string to escape
  * @param mode The escaping mode: "disabled", "normal", "strict", or "veryStrict"
+ * @param shouldEscapeHashTags Whether to apply context-sensitive # escaping
  * @returns The escaped string
  * @throws Error if input is null or undefined
  *
@@ -14,39 +41,53 @@
 export function escapeBody(
 	unsafe: string,
 	mode: "disabled" | "normal" | "strict" | "veryStrict" = "normal",
+	shouldEscapeHashTags: boolean = false,
 ): string {
+	// Validate input
 	if (unsafe === null || unsafe === undefined) {
 		throw new Error("Input cannot be null or undefined");
 	}
 
+	// No escaping in disabled mode
 	if (mode === "disabled") {
 		return unsafe;
 	}
 
-	if (mode === "strict") {
-		// Allow Unicode characters, whitespace, common punctuation, and URL/Markdown specific characters
-		// Remove potentially dangerous characters while preserving Chinese and other Unicode characters
-		return unsafe
-			.replace(/[<>{}$`\\]/g, "")  // Remove potentially dangerous HTML/JS/template characters
-			.replace(/---/g, "- - -");  // Escape YAML frontmatter separators
+	// Apply mode-specific escaping
+	let escaped: string;
+
+	switch (mode) {
+		case "strict":
+			// Allow Unicode characters, whitespace, common punctuation, and URL/Markdown specific characters
+			// Remove potentially dangerous characters while preserving Chinese and other Unicode characters
+			escaped = unsafe
+				.replace(/[<>{}$`\\]/g, "")  // Remove potentially dangerous HTML/JS/template characters
+				.replace(/---/g, "- - -");  // Escape YAML frontmatter separators
+			break;
+
+		case "veryStrict":
+			// Allow Unicode characters, whitespace, basic punctuation, and essential URL/Markdown characters
+			// More restrictive than strict mode but still preserves Chinese and other Unicode characters
+			escaped = unsafe
+				.replace(/[<>{}$`\\"'|&*~^]/g, "")  // Remove more potentially dangerous characters
+				.replace(/---/g, "- - -");  // Escape YAML frontmatter separators
+			break;
+
+		case "normal":
+		default:
+			// Basic escaping for Templater and Dataview compatibility
+			escaped = unsafe
+				.replace(/<%/g, "'<<'")    // Templater tags
+				.replace(/%>/g, "'>>'")    // Templater tags
+				.replace(/`/g, '"')        // Backticks (can interfere with Dataview)
+				.replace(/---/g, "- - -")  // YAML frontmatter separators
+				.replace(/{{/g, "((")      // Templater/Dataview variables
+				.replace(/}}/g, "))");     // Templater/Dataview variables
+			break;
 	}
 
-	if (mode === "veryStrict") {
-		// Allow Unicode characters, whitespace, basic punctuation, and essential URL/Markdown characters
-		// More restrictive than strict mode but still preserves Chinese and other Unicode characters
-		return unsafe
-			.replace(/[<>{}$`\\"'|&*~^]/g, "")  // Remove more potentially dangerous characters
-			.replace(/---/g, "- - -");  // Escape YAML frontmatter separators
-	}
-
-	// normal mode
-	return unsafe
-		.replace(/<%/g, "'<<'")
-		.replace(/%>/g, "'>>'")
-		.replace(/`/g, '"')
-		.replace(/---/g, "- - -")
-		.replace(/{{/g, "((")
-		.replace(/}}/g, "))");
+	// Apply context-sensitive # escaping if enabled
+	return shouldEscapeHashTags ? escapeHashTags(escaped) : escaped;
 }
 
 /**
@@ -56,5 +97,7 @@ export function escapeBody(
  */
 export function escapeYamlString(str: string): string {
 	// In YAML double-quoted strings, we need to escape backslashes and double quotes
-	return str.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+	return str
+		.replace(/\\/g, '\\\\')  // Escape backslashes first
+		.replace(/"/g, '\\"');   // Then escape double quotes
 }

--- a/src/util/file-helpers.ts
+++ b/src/util/file-helpers.ts
@@ -57,6 +57,7 @@ export class FileHelpers {
 		comments: any[],
 		escapeMode: "disabled" | "normal" | "strict" | "veryStrict",
 		dateFormat: string,
+		escapeHashTags: boolean = false,
 	): string {
 		if (!comments || comments.length === 0) {
 			return "";
@@ -87,6 +88,7 @@ export class FileHelpers {
 			commentSection += `${escapeBody(
 				comment.body || "No content",
 				escapeMode,
+				escapeHashTags,
 			)}\n\n---\n\n`;
 		});
 

--- a/src/util/templateUtils.ts
+++ b/src/util/templateUtils.ts
@@ -67,12 +67,14 @@ export function sanitizeFilename(filename: string): string {
  * @param comments Array of comment objects from GitHub API
  * @param dateFormat Date format string for comment timestamps
  * @param escapeMode Escape mode for comment body text
+ * @param escapeHashTags Whether to escape # characters
  * @returns Formatted comments string
  */
 export function formatComments(
 	comments: any[],
 	dateFormat: string = "",
-	escapeMode: "disabled" | "normal" | "strict" | "veryStrict" = "normal"
+	escapeMode: "disabled" | "normal" | "strict" | "veryStrict" = "normal",
+	escapeHashTags: boolean = false
 ): string {
 	if (!comments || comments.length === 0) {
 		return "";
@@ -102,7 +104,8 @@ export function formatComments(
 		// Use escapeBody function for proper text escaping
 		commentSection += `${escapeBody(
 			comment.body || "No content",
-			escapeMode
+			escapeMode,
+			escapeHashTags
 		)}\n\n`;
 	});
 
@@ -293,7 +296,8 @@ export function createIssueTemplateData(
 	repository: string,
 	comments: any[] = [],
 	dateFormat: string = "",
-	escapeMode: "disabled" | "normal" | "strict" | "veryStrict" = "normal"
+	escapeMode: "disabled" | "normal" | "strict" | "veryStrict" = "normal",
+	escapeHashTags: boolean = false
 ): TemplateData {
 	const [owner, repoName] = repository.split("/");
 
@@ -323,7 +327,7 @@ export function createIssueTemplateData(
 		commentsCount: issue.comments || 0,
 		isLocked: issue.locked || false,
 		lockReason: issue.active_lock_reason || "",
-		comments: formatComments(comments, dateFormat, escapeMode)
+		comments: formatComments(comments, dateFormat, escapeMode, escapeHashTags)
 	};
 }
 
@@ -338,7 +342,8 @@ export function createPullRequestTemplateData(
 	repository: string,
 	comments: any[] = [],
 	dateFormat: string = "",
-	escapeMode: "disabled" | "normal" | "strict" | "veryStrict" = "normal"
+	escapeMode: "disabled" | "normal" | "strict" | "veryStrict" = "normal",
+	escapeHashTags: boolean = false
 ): TemplateData {
 	const [owner, repoName] = repository.split("/");
 
@@ -374,7 +379,7 @@ export function createPullRequestTemplateData(
 		merged: pr.merged || false,
 		baseBranch: pr.base?.ref,
 		headBranch: pr.head?.ref,
-		comments: formatComments(comments, dateFormat, escapeMode)
+		comments: formatComments(comments, dateFormat, escapeMode, escapeHashTags)
 	};
 }
 


### PR DESCRIPTION
  Implement configurable escaping of # characters that are not valid
  Markdown headers to prevent unintended Obsidian tags.
  
  
  
  
  close: #27 