### PR TITLE
fix: GitLab group paths and Kanban project scoping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
             version: ${{ steps.version.outputs.version }}
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 0
             - name: Get next version
-              uses: thenativeweb/get-next-version@2.6.3
+              uses: thenativeweb/get-next-version@2.7.3
               id: version
 
     build-and-release:
@@ -29,14 +29,9 @@ jobs:
         if: needs.check-version.outputs.hasNextVersion == 'true'
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   fetch-depth: 0
-
-            - name: Use Node.js 22
-              uses: actions/setup-node@v2
-              with:
-                  node-version: "22"
 
             - name: Install Dependencies
               run: npm install

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -73,7 +73,7 @@ const context = await esbuild.context({
 	plugins: prod ? [] : [devCopyPlugin],
 });
 
-const devVaultPluginDir = "/mnt/games/Nextcloud/Obsidian/plugins/github-issues";
+const devVaultPluginDir = "/home/lonoxx/Documents/Dev-Vault";
 
 function copyToDevVault() {
 	if (!fs.existsSync(devVaultPluginDir)) {
@@ -90,7 +90,6 @@ function copyToDevVault() {
 
 if (prod) {
 	await context.rebuild();
-	copyToDist(["versions.json", "manifest.json", "styles.css"]);
 	process.exit(0);
 } else {
 	await context.watch();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,27 +1,27 @@
 {
 	"name": "github-issues",
-	"version": "1.9.0",
+	"version": "1.9.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "github-issues",
-			"version": "1.9.0",
+			"version": "1.9.2",
 			"license": "MIT",
 			"dependencies": {
 				"date-fns": "4.4.0",
 				"octokit": "5.0.5"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.2",
 				"esbuild": "^0.28.1",
-				"eslint": "^10.6.0",
+				"eslint": "^10.8.0",
 				"eslint-plugin-obsidianmd": "^0.4.1",
 				"obsidian": "^1.13.1",
-				"prettier": "^3.9.4",
+				"prettier": "^3.9.6",
 				"tslib": "^2.8.1",
 				"typescript": "^6.0.3",
-				"typescript-eslint": "^8.62.1"
+				"typescript-eslint": "^8.66.0"
 			}
 		},
 		"node_modules/@codemirror/state": {
@@ -50,9 +50,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
-			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+			"integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -67,9 +67,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
-			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+			"integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
 			"cpu": [
 				"arm"
 			],
@@ -84,9 +84,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
-			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+			"integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
 			"cpu": [
 				"arm64"
 			],
@@ -101,9 +101,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
-			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+			"integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
 			"cpu": [
 				"x64"
 			],
@@ -118,9 +118,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+			"integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
 			"cpu": [
 				"arm64"
 			],
@@ -135,9 +135,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+			"integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
 			"cpu": [
 				"x64"
 			],
@@ -152,9 +152,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
-			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
 			"cpu": [
 				"arm64"
 			],
@@ -169,9 +169,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
-			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+			"integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
 			"cpu": [
 				"x64"
 			],
@@ -186,9 +186,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
-			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+			"integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
 			"cpu": [
 				"arm"
 			],
@@ -203,9 +203,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
-			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+			"integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
 			"cpu": [
 				"arm64"
 			],
@@ -220,9 +220,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
-			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+			"integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -237,9 +237,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
-			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+			"integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
 			"cpu": [
 				"loong64"
 			],
@@ -254,9 +254,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
-			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+			"integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
 			"cpu": [
 				"mips64el"
 			],
@@ -271,9 +271,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
-			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+			"integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -288,9 +288,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
-			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+			"integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -305,9 +305,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
-			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+			"integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
 			"cpu": [
 				"s390x"
 			],
@@ -322,9 +322,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+			"integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
 			"cpu": [
 				"x64"
 			],
@@ -339,9 +339,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
-			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
 			"cpu": [
 				"arm64"
 			],
@@ -356,9 +356,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
-			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+			"integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
 			"cpu": [
 				"x64"
 			],
@@ -373,9 +373,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
-			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -390,9 +390,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
-			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+			"integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
 			"cpu": [
 				"x64"
 			],
@@ -407,9 +407,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
-			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+			"integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -424,9 +424,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
-			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+			"integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
 			"cpu": [
 				"x64"
 			],
@@ -441,9 +441,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
-			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+			"integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -458,9 +458,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
-			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+			"integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
 			"cpu": [
 				"ia32"
 			],
@@ -475,9 +475,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
-			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+			"integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
 			"cpu": [
 				"x64"
 			],
@@ -512,9 +512,9 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-plugin-eslint-comments/node_modules/ignore": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+			"integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -522,9 +522,9 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-			"integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+			"integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -579,9 +579,9 @@
 			}
 		},
 		"node_modules/@eslint/config-helpers": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-			"integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+			"integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -605,9 +605,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "3.3.5",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-			"integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+			"integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -617,7 +617,7 @@
 				"globals": "^14.0.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
-				"js-yaml": "^4.1.1",
+				"js-yaml": "^4.3.0",
 				"minimatch": "^3.1.5",
 				"strip-json-comments": "^3.1.1"
 			},
@@ -636,9 +636,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -691,9 +691,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.39.4",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-			"integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+			"version": "9.39.5",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+			"integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -855,34 +855,64 @@
 			"peer": true
 		},
 		"node_modules/@octokit/app": {
-			"version": "16.1.2",
-			"resolved": "https://registry.npmjs.org/@octokit/app/-/app-16.1.2.tgz",
-			"integrity": "sha512-8j7sEpUYVj18dxvh0KWj6W/l6uAiVRBl1JBDVRqH1VHKAO/G5eRVl4yEoYACjakWers1DjUkcCHyJNQK47JqyQ==",
+			"version": "16.1.4",
+			"resolved": "https://registry.npmjs.org/@octokit/app/-/app-16.1.4.tgz",
+			"integrity": "sha512-g70WONQyGoBgqIJtv4O0MUEfOF1iJpTfFt3qAW7HaiwiJ6k607xg/gBezCa4tuq6BpO6qXn7qvq8v9tjWtgGQg==",
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/auth-app": "^8.1.2",
-				"@octokit/auth-unauthenticated": "^7.0.3",
-				"@octokit/core": "^7.0.6",
-				"@octokit/oauth-app": "^8.0.3",
-				"@octokit/plugin-paginate-rest": "^14.0.0",
-				"@octokit/types": "^16.0.0",
+				"@octokit/auth-app": "^8.3.0",
+				"@octokit/auth-unauthenticated": "^7.0.4",
+				"@octokit/core": "^7.0.7",
+				"@octokit/oauth-app": "^8.0.4",
+				"@octokit/plugin-paginate-rest": "^15.0.0",
+				"@octokit/types": "^17.0.0",
 				"@octokit/webhooks": "^14.0.0"
 			},
 			"engines": {
 				"node": ">= 20"
 			}
 		},
-		"node_modules/@octokit/auth-app": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-8.2.0.tgz",
-			"integrity": "sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g==",
+		"node_modules/@octokit/app/node_modules/@octokit/openapi-types": {
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+			"integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/app/node_modules/@octokit/plugin-paginate-rest": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-15.0.0.tgz",
+			"integrity": "sha512-lw9A9YL5s4VPj+VEx8uMxaxQm2YTgrPDkrLEuZuu18R8TK3oPcXF4K6t52nx6xn1RcogZC9i188sAr/4XYJaQQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/auth-oauth-app": "^9.0.3",
-				"@octokit/auth-oauth-user": "^6.0.2",
-				"@octokit/request": "^10.0.6",
-				"@octokit/request-error": "^7.0.2",
-				"@octokit/types": "^16.0.0",
+				"@octokit/types": "^17.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=6"
+			}
+		},
+		"node_modules/@octokit/app/node_modules/@octokit/types": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^28.0.0"
+			}
+		},
+		"node_modules/@octokit/auth-app": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-8.3.0.tgz",
+			"integrity": "sha512-/UaKmJCsOc5XBZwhnFiGNdLH/FkDF8lYtBn1QlKxtX7IpgaRB/XOXjixFtERAknyUZHxp3oDuoiG0En4VptJSg==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-oauth-app": "^9.0.4",
+				"@octokit/auth-oauth-user": "^6.0.3",
+				"@octokit/request": "^10.0.13",
+				"@octokit/request-error": "^7.1.1",
+				"@octokit/types": "^17.0.0",
 				"toad-cache": "^3.7.0",
 				"universal-github-app-jwt": "^2.2.0",
 				"universal-user-agent": "^7.0.0"
@@ -891,51 +921,111 @@
 				"node": ">= 20"
 			}
 		},
-		"node_modules/@octokit/auth-oauth-app": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-9.0.3.tgz",
-			"integrity": "sha512-+yoFQquaF8OxJSxTb7rnytBIC2ZLbLqA/yb71I4ZXT9+Slw4TziV9j/kyGhUFRRTF2+7WlnIWsePZCWHs+OGjg==",
+		"node_modules/@octokit/auth-app/node_modules/@octokit/openapi-types": {
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+			"integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-app/node_modules/@octokit/types": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/auth-oauth-device": "^8.0.3",
-				"@octokit/auth-oauth-user": "^6.0.2",
-				"@octokit/request": "^10.0.6",
-				"@octokit/types": "^16.0.0",
+				"@octokit/openapi-types": "^28.0.0"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-app": {
+			"version": "9.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-9.0.4.tgz",
+			"integrity": "sha512-Pe3du5LrC6dlv10b0RbarBlJtIT1Urq8BFoQklK8WmBw8YKnGgrANn7cQmHiA1v8AVihgi7YutV8MncP57I4og==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-oauth-device": "^8.0.4",
+				"@octokit/auth-oauth-user": "^6.0.3",
+				"@octokit/request": "^10.0.13",
+				"@octokit/types": "^17.0.0",
 				"universal-user-agent": "^7.0.0"
 			},
 			"engines": {
 				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-app/node_modules/@octokit/openapi-types": {
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+			"integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-oauth-app/node_modules/@octokit/types": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^28.0.0"
 			}
 		},
 		"node_modules/@octokit/auth-oauth-device": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-8.0.3.tgz",
-			"integrity": "sha512-zh2W0mKKMh/VWZhSqlaCzY7qFyrgd9oTWmTmHaXnHNeQRCZr/CXy2jCgHo4e4dJVTiuxP5dLa0YM5p5QVhJHbw==",
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-8.0.4.tgz",
+			"integrity": "sha512-M/+34rmkxMvUnnTo/uqNeVRCXJoJ+5N34eNTbL1KMtIyJpedCTsu/iFL1cWdL+w5hQMlYt6xzXoyux2gn0OVnw==",
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/oauth-methods": "^6.0.2",
-				"@octokit/request": "^10.0.6",
-				"@octokit/types": "^16.0.0",
+				"@octokit/oauth-methods": "^6.0.3",
+				"@octokit/request": "^10.0.13",
+				"@octokit/types": "^17.0.0",
 				"universal-user-agent": "^7.0.0"
 			},
 			"engines": {
 				"node": ">= 20"
 			}
 		},
-		"node_modules/@octokit/auth-oauth-user": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-6.0.2.tgz",
-			"integrity": "sha512-qLoPPc6E6GJoz3XeDG/pnDhJpTkODTGG4kY0/Py154i/I003O9NazkrwJwRuzgCalhzyIeWQ+6MDvkUmKXjg/A==",
+		"node_modules/@octokit/auth-oauth-device/node_modules/@octokit/openapi-types": {
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+			"integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-oauth-device/node_modules/@octokit/types": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/auth-oauth-device": "^8.0.3",
-				"@octokit/oauth-methods": "^6.0.2",
-				"@octokit/request": "^10.0.6",
-				"@octokit/types": "^16.0.0",
+				"@octokit/openapi-types": "^28.0.0"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-user": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-6.0.3.tgz",
+			"integrity": "sha512-t4OKUhrI5britmpRiSzPAz1TJPyUN/Hw1HEE3Hz/uElxcmnf/YCRSKtFRNc5gy4yJFTlXgk34H1lvxiotQJQvQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-oauth-device": "^8.0.4",
+				"@octokit/oauth-methods": "^6.0.3",
+				"@octokit/request": "^10.0.13",
+				"@octokit/types": "^17.0.0",
 				"universal-user-agent": "^7.0.0"
 			},
 			"engines": {
 				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-user/node_modules/@octokit/openapi-types": {
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+			"integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-oauth-user/node_modules/@octokit/types": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^28.0.0"
 			}
 		},
 		"node_modules/@octokit/auth-token": {
@@ -948,29 +1038,44 @@
 			}
 		},
 		"node_modules/@octokit/auth-unauthenticated": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-7.0.3.tgz",
-			"integrity": "sha512-8Jb1mtUdmBHL7lGmop9mU9ArMRUTRhg8vp0T1VtZ4yd9vEm3zcLwmjQkhNEduKawOOORie61xhtYIhTDN+ZQ3g==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-7.0.4.tgz",
+			"integrity": "sha512-j4zgVdP8C8C53PNsj4LLI+WFtoykaQARwwrIBILTdxwZ2Ljaa9YUxb1yQ7/seGVnmWPdC3OBefX3LLbh28gKtw==",
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/request-error": "^7.0.2",
-				"@octokit/types": "^16.0.0"
+				"@octokit/request-error": "^7.1.1",
+				"@octokit/types": "^17.0.0"
 			},
 			"engines": {
 				"node": ">= 20"
 			}
 		},
+		"node_modules/@octokit/auth-unauthenticated/node_modules/@octokit/openapi-types": {
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+			"integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-unauthenticated/node_modules/@octokit/types": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^28.0.0"
+			}
+		},
 		"node_modules/@octokit/core": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
-			"integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+			"version": "7.0.7",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.7.tgz",
+			"integrity": "sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/auth-token": "^6.0.0",
-				"@octokit/graphql": "^9.0.3",
-				"@octokit/request": "^10.0.6",
-				"@octokit/request-error": "^7.0.2",
-				"@octokit/types": "^16.0.0",
+				"@octokit/graphql": "^9.0.4",
+				"@octokit/request": "^10.0.13",
+				"@octokit/request-error": "^7.1.1",
+				"@octokit/types": "^17.0.0",
 				"before-after-hook": "^4.0.0",
 				"universal-user-agent": "^7.0.0"
 			},
@@ -978,45 +1083,90 @@
 				"node": ">= 20"
 			}
 		},
-		"node_modules/@octokit/endpoint": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
-			"integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+		"node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+			"integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/core/node_modules/@octokit/types": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^16.0.0",
+				"@octokit/openapi-types": "^28.0.0"
+			}
+		},
+		"node_modules/@octokit/endpoint": {
+			"version": "11.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.4.tgz",
+			"integrity": "sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^17.0.0",
 				"universal-user-agent": "^7.0.2"
 			},
 			"engines": {
 				"node": ">= 20"
 			}
 		},
-		"node_modules/@octokit/graphql": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
-			"integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+		"node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+			"integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/endpoint/node_modules/@octokit/types": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/request": "^10.0.6",
-				"@octokit/types": "^16.0.0",
+				"@octokit/openapi-types": "^28.0.0"
+			}
+		},
+		"node_modules/@octokit/graphql": {
+			"version": "9.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.4.tgz",
+			"integrity": "sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request": "^10.0.13",
+				"@octokit/types": "^17.0.0",
 				"universal-user-agent": "^7.0.0"
 			},
 			"engines": {
 				"node": ">= 20"
 			}
 		},
-		"node_modules/@octokit/oauth-app": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-8.0.3.tgz",
-			"integrity": "sha512-jnAjvTsPepyUaMu9e69hYBuozEPgYqP4Z3UnpmvoIzHDpf8EXDGvTY1l1jK0RsZ194oRd+k6Hm13oRU8EoDFwg==",
+		"node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+			"integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/graphql/node_modules/@octokit/types": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/auth-oauth-app": "^9.0.2",
-				"@octokit/auth-oauth-user": "^6.0.1",
-				"@octokit/auth-unauthenticated": "^7.0.2",
-				"@octokit/core": "^7.0.5",
+				"@octokit/openapi-types": "^28.0.0"
+			}
+		},
+		"node_modules/@octokit/oauth-app": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-8.0.4.tgz",
+			"integrity": "sha512-Ji5JpRwAJcbOJkO4ij0tW6+GrQ8efpICnAca3o5xI8/HUNjqJu3hhG4cCZdXAHMKaOaQTFX0Yl+cpu61Rsx94A==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-oauth-app": "^9.0.4",
+				"@octokit/auth-oauth-user": "^6.0.3",
+				"@octokit/auth-unauthenticated": "^7.0.4",
+				"@octokit/core": "^7.0.7",
 				"@octokit/oauth-authorization-url": "^8.0.0",
-				"@octokit/oauth-methods": "^6.0.1",
+				"@octokit/oauth-methods": "^6.0.3",
 				"@types/aws-lambda": "^8.10.83",
 				"universal-user-agent": "^7.0.0"
 			},
@@ -1034,18 +1184,33 @@
 			}
 		},
 		"node_modules/@octokit/oauth-methods": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-6.0.2.tgz",
-			"integrity": "sha512-HiNOO3MqLxlt5Da5bZbLV8Zarnphi4y9XehrbaFMkcoJ+FL7sMxH/UlUsCVxpddVu4qvNDrBdaTVE2o4ITK8ng==",
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-6.0.4.tgz",
+			"integrity": "sha512-96RsnxS7Hk/BQhUA1Qo2pmcYP6LWQRWMdo7bVbNE7ZCkFLhSUYBXVUj9tVnvhl4jzbwHYt/dcIG+ioY427b2sg==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/oauth-authorization-url": "^8.0.0",
-				"@octokit/request": "^10.0.6",
-				"@octokit/request-error": "^7.0.2",
-				"@octokit/types": "^16.0.0"
+				"@octokit/request": "^10.0.13",
+				"@octokit/request-error": "^7.1.1",
+				"@octokit/types": "^17.0.0"
 			},
 			"engines": {
 				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/oauth-methods/node_modules/@octokit/openapi-types": {
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+			"integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/oauth-methods/node_modules/@octokit/types": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^28.0.0"
 			}
 		},
 		"node_modules/@octokit/openapi-types": {
@@ -1103,13 +1268,13 @@
 			}
 		},
 		"node_modules/@octokit/plugin-retry": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.1.0.tgz",
-			"integrity": "sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.1.1.tgz",
+			"integrity": "sha512-VCVvZ/R1+u3WuiBWpNavZ0mY4aaJNAsENrpBP9aLSR2QyOpQgd7DhM5j4AW7z4MQpnJYgwBPf0XqPQoNBRdQwg==",
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/request-error": "^7.0.2",
-				"@octokit/types": "^16.0.0",
+				"@octokit/request-error": "^7.1.1",
+				"@octokit/types": "^17.0.0",
 				"bottleneck": "^2.15.3"
 			},
 			"engines": {
@@ -1119,13 +1284,28 @@
 				"@octokit/core": ">=7"
 			}
 		},
-		"node_modules/@octokit/plugin-throttling": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.3.tgz",
-			"integrity": "sha512-34eE0RkFCKycLl2D2kq7W+LovheM/ex3AwZCYN8udpi6bxsyjZidb2McXs69hZhLmJlDqTSP8cH+jSRpiaijBg==",
+		"node_modules/@octokit/plugin-retry/node_modules/@octokit/openapi-types": {
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+			"integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/plugin-retry/node_modules/@octokit/types": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^16.0.0",
+				"@octokit/openapi-types": "^28.0.0"
+			}
+		},
+		"node_modules/@octokit/plugin-throttling": {
+			"version": "11.0.5",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.5.tgz",
+			"integrity": "sha512-LIdrkrUv+DWbKeg/49rGuFJ3SU0d3hUS+B4MhNZLepBoNUFXms8Ic9edJjrlx+zycqJHjrMRudVpVb/bAXM2Lw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^17.0.0",
 				"bottleneck": "^2.15.3"
 			},
 			"engines": {
@@ -1135,15 +1315,30 @@
 				"@octokit/core": "^7.0.0"
 			}
 		},
+		"node_modules/@octokit/plugin-throttling/node_modules/@octokit/openapi-types": {
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+			"integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/plugin-throttling/node_modules/@octokit/types": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^28.0.0"
+			}
+		},
 		"node_modules/@octokit/request": {
-			"version": "10.0.11",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.11.tgz",
-			"integrity": "sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==",
+			"version": "10.0.13",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.13.tgz",
+			"integrity": "sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/endpoint": "^11.0.3",
-				"@octokit/request-error": "^7.0.2",
-				"@octokit/types": "^16.0.0",
+				"@octokit/request-error": "^7.1.1",
+				"@octokit/types": "^17.0.0",
 				"content-type": "^2.0.0",
 				"json-with-bigint": "^3.5.3",
 				"universal-user-agent": "^7.0.2"
@@ -1153,15 +1348,45 @@
 			}
 		},
 		"node_modules/@octokit/request-error": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
-			"integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.1.tgz",
+			"integrity": "sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==",
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^16.0.0"
+				"@octokit/types": "^17.0.0"
 			},
 			"engines": {
 				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+			"integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/request-error/node_modules/@octokit/types": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^28.0.0"
+			}
+		},
+		"node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+			"integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/request/node_modules/@octokit/types": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^28.0.0"
 			}
 		},
 		"node_modules/@octokit/types": {
@@ -1272,9 +1497,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "26.1.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
-			"integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+			"version": "26.2.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+			"integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1292,17 +1517,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
-			"integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
+			"version": "8.67.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
+			"integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.62.1",
-				"@typescript-eslint/type-utils": "8.62.1",
-				"@typescript-eslint/utils": "8.62.1",
-				"@typescript-eslint/visitor-keys": "8.62.1",
+				"@typescript-eslint/scope-manager": "8.67.0",
+				"@typescript-eslint/type-utils": "8.67.0",
+				"@typescript-eslint/utils": "8.67.0",
+				"@typescript-eslint/visitor-keys": "8.67.0",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -1315,15 +1540,15 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.62.1",
+				"@typescript-eslint/parser": "^8.67.0",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+			"integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1331,16 +1556,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
-			"integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
+			"version": "8.67.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
+			"integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.62.1",
-				"@typescript-eslint/types": "8.62.1",
-				"@typescript-eslint/typescript-estree": "8.62.1",
-				"@typescript-eslint/visitor-keys": "8.62.1",
+				"@typescript-eslint/scope-manager": "8.67.0",
+				"@typescript-eslint/types": "8.67.0",
+				"@typescript-eslint/typescript-estree": "8.67.0",
+				"@typescript-eslint/visitor-keys": "8.67.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -1356,14 +1581,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
-			"integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
+			"version": "8.67.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+			"integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.62.1",
-				"@typescript-eslint/types": "^8.62.1",
+				"@typescript-eslint/tsconfig-utils": "^8.67.0",
+				"@typescript-eslint/types": "^8.67.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -1378,14 +1603,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
-			"integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
+			"version": "8.67.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
+			"integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.62.1",
-				"@typescript-eslint/visitor-keys": "8.62.1"
+				"@typescript-eslint/types": "8.67.0",
+				"@typescript-eslint/visitor-keys": "8.67.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1396,9 +1621,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
-			"integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
+			"version": "8.67.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+			"integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1413,15 +1638,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
-			"integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
+			"version": "8.67.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+			"integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.62.1",
-				"@typescript-eslint/typescript-estree": "8.62.1",
-				"@typescript-eslint/utils": "8.62.1",
+				"@typescript-eslint/types": "8.67.0",
+				"@typescript-eslint/typescript-estree": "8.67.0",
+				"@typescript-eslint/utils": "8.67.0",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -1438,9 +1663,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
-			"integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
+			"version": "8.67.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
+			"integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1452,16 +1677,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
-			"integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
+			"version": "8.67.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+			"integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.62.1",
-				"@typescript-eslint/tsconfig-utils": "8.62.1",
-				"@typescript-eslint/types": "8.62.1",
-				"@typescript-eslint/visitor-keys": "8.62.1",
+				"@typescript-eslint/project-service": "8.67.0",
+				"@typescript-eslint/tsconfig-utils": "8.67.0",
+				"@typescript-eslint/types": "8.67.0",
+				"@typescript-eslint/visitor-keys": "8.67.0",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -1480,16 +1705,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
-			"integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
+			"version": "8.67.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+			"integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.62.1",
-				"@typescript-eslint/types": "8.62.1",
-				"@typescript-eslint/typescript-estree": "8.62.1"
+				"@typescript-eslint/scope-manager": "8.67.0",
+				"@typescript-eslint/types": "8.67.0",
+				"@typescript-eslint/typescript-estree": "8.67.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1504,13 +1729,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
-			"integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
+			"version": "8.67.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
+			"integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.62.1",
+				"@typescript-eslint/types": "8.67.0",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -1522,9 +1747,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.17.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-			"integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+			"integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -1793,16 +2018,16 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/call-bind": {
@@ -2109,9 +2334,9 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.24.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.1.tgz",
-			"integrity": "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==",
+			"version": "5.24.5",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+			"integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2231,9 +2456,9 @@
 			}
 		},
 		"node_modules/es-iterator-helpers": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
-			"integrity": "sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.4.0.tgz",
+			"integrity": "sha512-c/A0P0oxkACDc+cKWw8evLXK83oBKgn0qPOqCYT4x9uolpCIJAcYvJC9QYKNDRPsTeGyCrQ326jrvgZWdCdK5Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2322,9 +2547,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+			"integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -2335,32 +2560,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.28.1",
-				"@esbuild/android-arm": "0.28.1",
-				"@esbuild/android-arm64": "0.28.1",
-				"@esbuild/android-x64": "0.28.1",
-				"@esbuild/darwin-arm64": "0.28.1",
-				"@esbuild/darwin-x64": "0.28.1",
-				"@esbuild/freebsd-arm64": "0.28.1",
-				"@esbuild/freebsd-x64": "0.28.1",
-				"@esbuild/linux-arm": "0.28.1",
-				"@esbuild/linux-arm64": "0.28.1",
-				"@esbuild/linux-ia32": "0.28.1",
-				"@esbuild/linux-loong64": "0.28.1",
-				"@esbuild/linux-mips64el": "0.28.1",
-				"@esbuild/linux-ppc64": "0.28.1",
-				"@esbuild/linux-riscv64": "0.28.1",
-				"@esbuild/linux-s390x": "0.28.1",
-				"@esbuild/linux-x64": "0.28.1",
-				"@esbuild/netbsd-arm64": "0.28.1",
-				"@esbuild/netbsd-x64": "0.28.1",
-				"@esbuild/openbsd-arm64": "0.28.1",
-				"@esbuild/openbsd-x64": "0.28.1",
-				"@esbuild/openharmony-arm64": "0.28.1",
-				"@esbuild/sunos-x64": "0.28.1",
-				"@esbuild/win32-arm64": "0.28.1",
-				"@esbuild/win32-ia32": "0.28.1",
-				"@esbuild/win32-x64": "0.28.1"
+				"@esbuild/aix-ppc64": "0.28.2",
+				"@esbuild/android-arm": "0.28.2",
+				"@esbuild/android-arm64": "0.28.2",
+				"@esbuild/android-x64": "0.28.2",
+				"@esbuild/darwin-arm64": "0.28.2",
+				"@esbuild/darwin-x64": "0.28.2",
+				"@esbuild/freebsd-arm64": "0.28.2",
+				"@esbuild/freebsd-x64": "0.28.2",
+				"@esbuild/linux-arm": "0.28.2",
+				"@esbuild/linux-arm64": "0.28.2",
+				"@esbuild/linux-ia32": "0.28.2",
+				"@esbuild/linux-loong64": "0.28.2",
+				"@esbuild/linux-mips64el": "0.28.2",
+				"@esbuild/linux-ppc64": "0.28.2",
+				"@esbuild/linux-riscv64": "0.28.2",
+				"@esbuild/linux-s390x": "0.28.2",
+				"@esbuild/linux-x64": "0.28.2",
+				"@esbuild/netbsd-arm64": "0.28.2",
+				"@esbuild/netbsd-x64": "0.28.2",
+				"@esbuild/openbsd-arm64": "0.28.2",
+				"@esbuild/openbsd-x64": "0.28.2",
+				"@esbuild/openharmony-arm64": "0.28.2",
+				"@esbuild/sunos-x64": "0.28.2",
+				"@esbuild/win32-arm64": "0.28.2",
+				"@esbuild/win32-ia32": "0.28.2",
+				"@esbuild/win32-x64": "0.28.2"
 			}
 		},
 		"node_modules/escape-string-regexp": {
@@ -2377,9 +2602,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "10.6.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
-			"integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+			"version": "10.8.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
+			"integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
 			"dev": true,
 			"license": "MIT",
 			"workspaces": [
@@ -2389,7 +2614,7 @@
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.2",
 				"@eslint/config-array": "^0.23.5",
-				"@eslint/config-helpers": "^0.6.0",
+				"@eslint/config-helpers": "^0.7.0",
 				"@eslint/core": "^1.2.1",
 				"@eslint/plugin-kit": "^0.7.2",
 				"@humanfs/node": "^0.16.6",
@@ -2413,7 +2638,7 @@
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"minimatch": "^10.2.4",
+				"minimatch": "^10.2.5",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3"
 			},
@@ -2589,9 +2814,9 @@
 			"license": "MIT"
 		},
 		"node_modules/eslint-plugin-json-schema-validator/node_modules/brace-expansion": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+			"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2655,9 +2880,9 @@
 			"license": "MIT"
 		},
 		"node_modules/eslint-plugin-n/node_modules/brace-expansion": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+			"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2856,9 +3081,9 @@
 			"license": "MIT"
 		},
 		"node_modules/eslint-plugin-obsidianmd/node_modules/brace-expansion": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2867,9 +3092,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-obsidianmd/node_modules/eslint": {
-			"version": "9.39.4",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-			"integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+			"version": "9.39.5",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+			"integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2878,8 +3103,8 @@
 				"@eslint/config-array": "^0.21.2",
 				"@eslint/config-helpers": "^0.4.2",
 				"@eslint/core": "^0.17.0",
-				"@eslint/eslintrc": "^3.3.5",
-				"@eslint/js": "9.39.4",
+				"@eslint/eslintrc": "^3.3.6",
+				"@eslint/js": "9.39.5",
 				"@eslint/plugin-kit": "^0.4.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
@@ -3258,9 +3483,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-			"integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3337,9 +3562,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+			"version": "3.4.4",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+			"integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -3471,9 +3696,9 @@
 			}
 		},
 		"node_modules/get-tsconfig": {
-			"version": "4.14.0",
-			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-			"integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.1.tgz",
+			"integrity": "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4130,9 +4355,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -4208,9 +4433,9 @@
 			"license": "MIT"
 		},
 		"node_modules/json-with-bigint": {
-			"version": "3.5.8",
-			"resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
-			"integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+			"version": "3.5.10",
+			"resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.10.tgz",
+			"integrity": "sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==",
 			"license": "MIT"
 		},
 		"node_modules/json5": {
@@ -4363,13 +4588,13 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "10.2.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"version": "10.2.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+			"integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^5.0.5"
+				"brace-expansion": "^5.0.8"
 			},
 			"engines": {
 				"node": "18 || 20 || >=22"
@@ -4627,13 +4852,14 @@
 			}
 		},
 		"node_modules/own-keys": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-			"integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+			"integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"get-intrinsic": "^1.2.6",
+				"call-bound": "^1.0.4",
+				"get-intrinsic": "^1.3.0",
 				"object-keys": "^1.1.1",
 				"safe-push-apply": "^1.0.0"
 			},
@@ -4750,9 +4976,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.9.4",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
-			"integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+			"version": "3.9.6",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+			"integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -5567,16 +5793,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.62.1",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
-			"integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
+			"version": "8.67.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.67.0.tgz",
+			"integrity": "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.62.1",
-				"@typescript-eslint/parser": "8.62.1",
-				"@typescript-eslint/typescript-estree": "8.62.1",
-				"@typescript-eslint/utils": "8.62.1"
+				"@typescript-eslint/eslint-plugin": "8.67.0",
+				"@typescript-eslint/parser": "8.67.0",
+				"@typescript-eslint/typescript-estree": "8.67.0",
+				"@typescript-eslint/utils": "8.67.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -21,15 +21,15 @@
 	"author": "LonoxX",
 	"license": "MIT",
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.2",
 		"esbuild": "^0.28.1",
-		"eslint": "^10.6.0",
+		"eslint": "^10.8.0",
 		"eslint-plugin-obsidianmd": "^0.4.1",
 		"obsidian": "^1.13.1",
-		"prettier": "^3.9.4",
+		"prettier": "^3.9.6",
 		"tslib": "^2.8.1",
 		"typescript": "^6.0.3",
-		"typescript-eslint": "^8.62.1"
+		"typescript-eslint": "^8.66.0"
 	},
 	"dependencies": {
 		"date-fns": "4.4.0",

--- a/src/cleanup-manager.ts
+++ b/src/cleanup-manager.ts
@@ -74,8 +74,7 @@ export class CleanupManager {
 
 				const correspondingIssue =
 					allIssuesIncludingRecentlyClosed.find(
-						(issue) =>
-							issue.number.toString() === fileNumberString,
+						(issue) => issue.number.toString() === fileNumberString,
 					);
 
 				let shouldDelete = false;
@@ -291,19 +290,10 @@ export class CleanupManager {
 					}
 				}
 
-				const issueOwnerFolder = this.app.vault.getAbstractFileByPath(
+				await this.pruneEmptyAncestors(
 					`${repo.issueFolder}/${ownerCleaned}`,
+					repo.issueFolder ?? "",
 				);
-
-				if (issueOwnerFolder instanceof TFolder) {
-					const files = issueOwnerFolder.children;
-					if (files.length === 0) {
-						this.noticeManager.info(
-							`Deleting empty folder: ${issueOwnerFolder.path}`,
-						);
-						await this.app.fileManager.trashFile(issueOwnerFolder);
-					}
-				}
 			}
 		}
 	}
@@ -364,23 +354,41 @@ export class CleanupManager {
 					}
 				}
 
-				const pullRequestOwnerFolder =
-					this.app.vault.getAbstractFileByPath(
-						`${repo.pullRequestFolder}/${ownerCleaned}`,
-					);
-
-				if (pullRequestOwnerFolder instanceof TFolder) {
-					const files = pullRequestOwnerFolder.children;
-					if (files.length === 0) {
-						this.noticeManager.info(
-							`Deleting empty folder: ${pullRequestOwnerFolder.path}`,
-						);
-						await this.app.fileManager.trashFile(
-							pullRequestOwnerFolder,
-						);
-					}
-				}
+				await this.pruneEmptyAncestors(
+					`${repo.pullRequestFolder}/${ownerCleaned}`,
+					repo.pullRequestFolder ?? "",
+				);
 			}
+		}
+	}
+
+	/**
+	 * Trash empty folders walking upwards from `startPath`, stopping before
+	 * `rootPath` (the configured issue/pull request root, which is never
+	 * touched). Nested GitLab groups mean the owner part of a path can be
+	 * several levels deep, so a single parent check is not enough.
+	 */
+	private async pruneEmptyAncestors(
+		startPath: string,
+		rootPath: string,
+	): Promise<void> {
+		const root = rootPath.replace(/\/+$/, "");
+		if (!root) return;
+
+		let current = startPath.replace(/\/+$/, "");
+
+		while (current !== root && current.startsWith(`${root}/`)) {
+			const folder = this.app.vault.getAbstractFileByPath(current);
+			if (!(folder instanceof TFolder) || folder.children.length > 0) {
+				return;
+			}
+
+			this.noticeManager.info(`Deleting empty folder: ${folder.path}`);
+			await this.app.fileManager.trashFile(folder);
+
+			const idx = current.lastIndexOf("/");
+			if (idx < 0) return;
+			current = current.slice(0, idx);
 		}
 	}
 }

--- a/src/file-manager.ts
+++ b/src/file-manager.ts
@@ -29,6 +29,11 @@ import {
 } from "./util/templateUtils";
 import { extractPersistBlocks, mergePersistBlocks } from "./util/persistUtils";
 import { getEffectiveProjectSettings } from "./util/settingsUtils";
+import {
+	parseRepository,
+	sanitizeFolderSegment,
+	sanitizeOwnerPath,
+} from "./util/repo-path";
 
 /** Full shape of a GraphQL project-item content node (Issue or PullRequest). */
 interface ProjectItemContentGQL {
@@ -133,11 +138,13 @@ export class FileManager {
 	public async cleanupEmptyFolders(): Promise<void> {
 		try {
 			for (const repo of this.settings.repositories) {
-				const [owner, repoName] = repo.repository.split("/");
+				const { owner, repo: repoName } = parseRepository(
+					repo.repository,
+				);
 				if (!owner || !repoName) continue;
 
-				const repoCleaned = repoName.replace(/\//g, "-");
-				const ownerCleaned = owner.replace(/\//g, "-");
+				const repoCleaned = sanitizeFolderSegment(repoName);
+				const ownerCleaned = sanitizeOwnerPath(owner);
 				const issueFolder = this.folderPathManager.getIssueFolderPath(
 					repo,
 					ownerCleaned,
@@ -206,7 +213,8 @@ export class FileManager {
 		const hiddenItemUrls = new Set<string>();
 
 		for (const item of items) {
-			const content = item.content as ProjectItemContentGQL | null | undefined;
+			const content = item.content as
+				ProjectItemContentGQL | null | undefined;
 			if (!content) {
 				skippedNoContent++;
 				continue;
@@ -261,7 +269,7 @@ export class FileManager {
 			let parentIssue: Issue | null = null;
 
 			if (isIssue && effectiveProject.includeSubIssues) {
-				const [owner, repoName] = repository.split("/");
+				const { owner, repo: repoName } = parseRepository(repository);
 				if (owner && repoName) {
 					subIssues =
 						(await this.provider.fetchSubIssues?.(
@@ -533,8 +541,7 @@ export class FileManager {
 		const author = content.author?.login || "";
 		const assignees =
 			content.assignees?.nodes?.map((a) => `"${a.login}"`) || [];
-		const labels =
-			content.labels?.nodes?.map((l) => `"${l.name}"`) || [];
+		const labels = content.labels?.nodes?.map((l) => `"${l.name}"`) || [];
 
 		let frontmatter = `---
 title: "${title}"
@@ -547,7 +554,8 @@ url: "${content.url || ""}"
 opened_by: "${author}"
 assignees: [${assignees.join(", ")}]
 labels: [${labels.join(", ")}]
-project: "${project.title}"
+project: "${escapeYamlString(project.title)}"
+project_id: "${project.id}"
 project_status: "${status}"`;
 
 		// Add PR-specific fields
@@ -632,8 +640,7 @@ ${subIssues
 		const customFields: Record<string, ProjectFieldValue> = {};
 		let priority: string | undefined;
 		let iteration:
-			| { title: string; startDate: string; duration: number }
-			| undefined;
+			{ title: string; startDate: string; duration: number } | undefined;
 
 		for (const fieldValue of fieldValues) {
 			if (!fieldValue.field?.name) continue;
@@ -749,9 +756,12 @@ ${subIssues
 			html_url: content.url,
 			body: content.body || "",
 			user: content.author as Issue["user"],
-			assignee: (content.assignees?.nodes?.[0] ?? null) as Issue["assignee"],
+			assignee: (content.assignees?.nodes?.[0] ??
+				null) as Issue["assignee"],
 			assignees: (content.assignees?.nodes ?? []) as Issue["assignees"],
-			labels: content.labels?.nodes?.map((l) => ({ name: l.name ?? "" })) ?? [],
+			labels:
+				content.labels?.nodes?.map((l) => ({ name: l.name ?? "" })) ??
+				[],
 			milestone: content.milestone,
 			comments: 0,
 			locked: false,
@@ -761,7 +771,9 @@ ${subIssues
 	/**
 	 * Convert GraphQL project item content to pull request format for template processing
 	 */
-	private convertToPullRequestFormat(content: ProjectItemContentGQL): PullRequest {
+	private convertToPullRequestFormat(
+		content: ProjectItemContentGQL,
+	): PullRequest {
 		return {
 			number: content.number ?? 0,
 			title: content.title,
@@ -773,19 +785,28 @@ ${subIssues
 			html_url: content.url,
 			body: content.body || "",
 			user: content.author as PullRequest["user"],
-			assignee: (content.assignees?.nodes?.[0] ?? null) as PullRequest["assignee"],
-			assignees: (content.assignees?.nodes ?? []) as PullRequest["assignees"],
-			requested_reviewers: content.reviewRequests?.nodes?.map(
-				(r) => r.requestedReviewer,
-			) ?? [],
-			labels: content.labels?.nodes?.map((l) => ({ name: l.name ?? "" })) ?? [],
+			assignee: (content.assignees?.nodes?.[0] ??
+				null) as PullRequest["assignee"],
+			assignees: (content.assignees?.nodes ??
+				[]) as PullRequest["assignees"],
+			requested_reviewers:
+				content.reviewRequests?.nodes?.map(
+					(r) => r.requestedReviewer,
+				) ?? [],
+			labels:
+				content.labels?.nodes?.map((l) => ({ name: l.name ?? "" })) ??
+				[],
 			milestone: content.milestone,
 			comments: 0,
 			locked: false,
 			merged: content.merged || false,
 			mergeable: content.mergeable ?? undefined,
-			base: content.baseRefName ? { ref: content.baseRefName } : undefined,
-			head: content.headRefName ? { ref: content.headRefName } : undefined,
+			base: content.baseRefName
+				? { ref: content.baseRefName }
+				: undefined,
+			head: content.headRefName
+				? { ref: content.headRefName }
+				: undefined,
 		};
 	}
 }

--- a/src/issue-file-manager.ts
+++ b/src/issue-file-manager.ts
@@ -9,6 +9,11 @@ import {
 	processFilenameTemplate,
 } from "./util/templateUtils";
 import { getEffectiveRepoSettings } from "./util/settingsUtils";
+import {
+	parseRepository,
+	sanitizeFolderSegment,
+	sanitizeOwnerPath,
+} from "./util/repo-path";
 import { extractPersistBlocks, mergePersistBlocks } from "./util/persistUtils";
 import { shouldUpdateContent, hasStatusChanged } from "./util/contentUtils";
 import { FileHelpers } from "./util/file-helpers";
@@ -46,10 +51,12 @@ export class IssueFileManager {
 		// Apply global defaults to repository settings
 		const effectiveRepo = getEffectiveRepoSettings(repo, this.settings);
 
-		const [owner, repoName] = effectiveRepo.repository.split("/");
+		const { owner, repo: repoName } = parseRepository(
+			effectiveRepo.repository,
+		);
 		if (!owner || !repoName) return;
-		const repoCleaned = repoName.replace(/\//g, "-");
-		const ownerCleaned = owner.replace(/\//g, "-");
+		const repoCleaned = sanitizeFolderSegment(repoName);
+		const ownerCleaned = sanitizeOwnerPath(owner);
 		await this.cleanupManager.cleanupDeletedIssues(
 			effectiveRepo,
 			ownerCleaned,
@@ -89,27 +96,10 @@ export class IssueFileManager {
 			repoCleaned,
 		);
 
-		// Ensure folder structure exists
-		if (
-			repo.useCustomIssueFolder &&
-			repo.customIssueFolder &&
-			repo.customIssueFolder.trim()
-		) {
-			// For custom folders, just ensure the custom path exists
-			await this.fileHelpers.ensureFolderExists(
-				repo.customIssueFolder.trim(),
-			);
-		} else {
-			// For default structure, ensure nested path exists
-			const issueFolder = repo.issueFolder ?? "GitHub";
-			await this.fileHelpers.ensureFolderExists(issueFolder);
-			await this.fileHelpers.ensureFolderExists(
-				`${issueFolder}/${ownerCleaned}`,
-			);
-			await this.fileHelpers.ensureFolderExists(
-				`${issueFolder}/${ownerCleaned}/${repoCleaned}`,
-			);
-		}
+		// Ensure folder structure exists. createFolder creates nested paths
+		// recursively, so a single call covers custom and default (owner may
+		// itself be a nested GitLab group path).
+		await this.fileHelpers.ensureFolderExists(issueFolderPath);
 
 		// Normalize folder path to use forward slashes for consistent vault lookups
 		const normalizedIssueFolderPath = issueFolderPath.replace(/\\/g, "/");
@@ -117,7 +107,7 @@ export class IssueFileManager {
 			`${normalizedIssueFolderPath}/${fileName}`,
 		);
 
-		const [owner, repoName] = repo.repository.split("/");
+		const { owner, repo: repoName } = parseRepository(repo.repository);
 		const extra: ProviderExtraParams | undefined = repo.gitlabProjectId
 			? { gitlabProjectId: repo.gitlabProjectId }
 			: undefined;
@@ -204,7 +194,10 @@ export class IssueFileManager {
 					// Check if content needs updating based on updated_at field
 					if (
 						!statusHasChanged &&
-						!shouldUpdateContent(existingContent, issue.updated_at ?? "")
+						!shouldUpdateContent(
+							existingContent,
+							issue.updated_at ?? "",
+						)
 					) {
 						this.noticeManager.debug(
 							`Skipped update for issue ${issue.number}: no changes detected (updated_at match)`,

--- a/src/kanban-view.ts
+++ b/src/kanban-view.ts
@@ -1,5 +1,9 @@
-import { ItemView, WorkspaceLeaf, Notice, setIcon } from "obsidian";
-import { IssueTrackerSettings, TrackedProject, ProjectFieldValue } from "./types";
+import { ItemView, WorkspaceLeaf, Notice, setIcon, TFile } from "obsidian";
+import {
+	IssueTrackerSettings,
+	TrackedProject,
+	ProjectFieldValue,
+} from "./types";
 import { IssueProvider } from "./providers/provider";
 import { getEffectiveProjectSettings } from "./util/settingsUtils";
 import { FolderPathManager } from "./folder-path-manager";
@@ -32,6 +36,7 @@ interface KanbanItem {
 	projectStatus: string;
 	customFields?: Record<string, ProjectFieldValue>;
 	labels?: Array<{ name: string; color?: string }>;
+	file?: TFile;
 	[key: string]: unknown;
 }
 
@@ -72,6 +77,61 @@ export class GitHubKanbanView extends ItemView {
 		const n = Number(s);
 		return isNaN(n) ? null : n;
 	}
+
+	/**
+	 * Collect every project a note explicitly declares it belongs to: the flat
+	 * "project_id" written by the project sync, plus any ids from a nested
+	 * "projectData:" list. These are stable node IDs, unlike the project title.
+	 */
+	private getDeclaredProjectIds(
+		frontmatter: Record<string, unknown>,
+	): string[] {
+		const ids: string[] = [];
+
+		const flatId = frontmatter.project_id;
+		if (typeof flatId === "string" && flatId.trim()) {
+			ids.push(flatId.trim());
+		}
+
+		const projectData = frontmatter.projectData;
+		if (Array.isArray(projectData)) {
+			for (const entry of projectData) {
+				if (!entry || typeof entry !== "object") continue;
+				const id = (entry as Record<string, unknown>).projectId;
+				if (typeof id !== "string" || !id.trim()) continue;
+				if (!ids.includes(id.trim())) ids.push(id.trim());
+			}
+		}
+
+		return ids;
+	}
+
+	/**
+	 * Frontmatter labels are plain strings, project data labels are objects.
+	 * The card renderer only understands the object form.
+	 */
+	private normalizeLabels(value: unknown): KanbanItem["labels"] {
+		if (!Array.isArray(value)) return [];
+		return value
+			.map((label) => {
+				if (typeof label === "string") return { name: label };
+				if (label && typeof label === "object") {
+					const rec = label as Record<string, unknown>;
+					if (typeof rec.name === "string") {
+						return {
+							name: rec.name,
+							color:
+								typeof rec.color === "string"
+									? rec.color
+									: undefined,
+						};
+					}
+				}
+				return null;
+			})
+			.filter((l): l is { name: string; color?: string } => l !== null);
+	}
+
 	private gitHubClient: IssueProvider | null = null;
 
 	constructor(
@@ -322,7 +382,7 @@ export class GitHubKanbanView extends ItemView {
 			}
 
 			this.projectDataCache.set(projectId, itemsArray);
-			} catch (error) {
+		} catch (error) {
 			console.error(
 				`Error loading project data for ${projectId}:`,
 				error,
@@ -444,7 +504,9 @@ export class GitHubKanbanView extends ItemView {
 			.concat(statuses.includes("No Status") ? ["No Status"] : []);
 	}
 
-	private async getProjectItems(project: TrackedProject): Promise<KanbanItem[]> {
+	private async getProjectItems(
+		project: TrackedProject,
+	): Promise<KanbanItem[]> {
 		const items: KanbanItem[] = [];
 
 		const trackedProject = this.settings.trackedProjects?.find(
@@ -468,10 +530,14 @@ export class GitHubKanbanView extends ItemView {
 			: undefined;
 
 		const files = this.app.vault.getMarkdownFiles();
-		const matchedNumbers = new Set<number>();
-		const matchedUrls = new Set<string>();
 		const cachedItemsForProject =
 			this.projectDataCache.get(project.id) || [];
+		// Every project the user still tracks. A note pointing at an id we no
+		// longer know about (project recreated, notes copied between vaults)
+		// must not silently disappear from every board.
+		const trackedProjectIds = new Set(
+			(this.settings.trackedProjects || []).map((p) => p.id),
+		);
 		const isFileInProjectFolder = (filePath: string): boolean => {
 			if (issueFolder && filePath.startsWith(issueFolder + "/"))
 				return true;
@@ -479,16 +545,13 @@ export class GitHubKanbanView extends ItemView {
 			return false;
 		};
 
-		// Build a set of normalized URLs from the cache for fast lookup
+		// Build a set of normalized URLs from the cache for fast lookup.
+		// Deliberately no set of issue numbers: numbers are only unique within
+		// a repository, so matching on them mixes separate projects together.
 		const cachedUrls = new Set(
 			cachedItemsForProject
 				.map((ci) => ci.normalizedUrl)
 				.filter((u): u is string => !!u),
-		);
-		const cachedNumbers = new Set(
-			cachedItemsForProject
-				.map((ci) => ci.number)
-				.filter((n): n is number => n !== undefined),
 		);
 
 		for (const file of files) {
@@ -501,64 +564,80 @@ export class GitHubKanbanView extends ItemView {
 				const fileMatchesProject =
 					frontmatter.project === project.title;
 
-				// Only apply the issue-frontmatter filter for files outside the project folder
-				if (!isInProjectFolder && !fileMatchesProject) {
-					const isIssue =
-						frontmatter.number &&
-						frontmatter.title &&
-						frontmatter.state;
-					if (!isIssue) continue;
-				}
+				const declaredProjectIds =
+					this.getDeclaredProjectIds(frontmatter);
+				const declaresThisProject = declaredProjectIds.includes(
+					project.id,
+				);
+				// Only trust a declaration that still points at a tracked project
+				const hasUsableDeclaration = declaredProjectIds.some((id) =>
+					trackedProjectIds.has(id),
+				);
+
 				const itemUrl = frontmatter.url as string | undefined;
-
-				// Fast pre-check: skip if not in folder, no project match, and not in cache
-				if (!isInProjectFolder && !fileMatchesProject) {
-					const fmNum = this.parseNumber(frontmatter.number);
-					const normUrl = this.normalizeUrl(itemUrl);
-					const inCache =
-						(normUrl && cachedUrls.has(normUrl)) ||
-						(fmNum !== null && cachedNumbers.has(fmNum));
-					if (!inCache) continue;
-				}
 				const normalizedItemUrl = this.normalizeUrl(itemUrl);
+				const isOnProjectBoard =
+					!!normalizedItemUrl && cachedUrls.has(normalizedItemUrl);
 
-				let fullProjectData: CachedProjectData | null = null;
-
-				// Try URL matching first (most reliable for cross-repository projects)
-				if (normalizedItemUrl) {
-					fullProjectData =
-						cachedItemsForProject.find(
-							(ci) => ci.normalizedUrl === normalizedItemUrl,
-						) || null;
-					if (fullProjectData && fullProjectData.normalizedUrl) {
-						matchedUrls.add(fullProjectData.normalizedUrl);
-					}
+				// Membership, strongest signal first:
+				// 1. the API says this item is on this board - a URL is globally
+				//    unique, and an item may legitimately sit on two boards
+				// 2. the note names a project id -> that beats where it happens to live
+				// 3. legacy notes without an id fall back to folder / project title
+				let belongsToProject: boolean;
+				if (isOnProjectBoard) {
+					belongsToProject = true;
+				} else if (hasUsableDeclaration) {
+					belongsToProject = declaresThisProject;
+				} else {
+					belongsToProject = isInProjectFolder || fileMatchesProject;
 				}
 
-				// Fall back to number matching only if URL didn't match
-				if (!fullProjectData) {
-					const fmNum = this.parseNumber(frontmatter.number);
-					if (fmNum !== null) {
+				if (belongsToProject) {
+					// A file pulled in purely by a URL match still has to look
+					// like an issue/PR note before it lands on the board
+					if (
+						!isInProjectFolder &&
+						!declaresThisProject &&
+						!fileMatchesProject
+					) {
+						const isIssue =
+							frontmatter.number &&
+							frontmatter.title &&
+							frontmatter.state;
+						if (!isIssue) continue;
+					}
+
+					let fullProjectData: CachedProjectData | null = null;
+
+					if (normalizedItemUrl) {
+						// URL matching only - reliable across repositories
 						fullProjectData =
 							cachedItemsForProject.find(
-								(ci) => Number(ci.number) === fmNum,
+								(ci) => ci.normalizedUrl === normalizedItemUrl,
 							) || null;
-						if (fullProjectData) {
-							matchedNumbers.add(fmNum);
+					} else {
+						// No URL to go by: fall back to the issue number, but
+						// only within this project's own items and only when
+						// the match is unambiguous, since numbers repeat
+						// across repositories
+						const fmNum = this.parseNumber(frontmatter.number);
+						if (fmNum !== null) {
+							const numberMatches = cachedItemsForProject.filter(
+								(ci) => Number(ci.number) === fmNum,
+							);
+							if (numberMatches.length === 1) {
+								fullProjectData = numberMatches[0];
+							}
 						}
 					}
-				}
 
-				if (
-					isInProjectFolder ||
-					fullProjectData ||
-					fileMatchesProject
-				) {
-					const projectStatus: string =
-						String(frontmatter.project_status ||
-						fullProjectData?.status ||
-						fullProjectData?.customFields?.Status?.value ||
-						"No Status");
+					const projectStatus: string = String(
+						frontmatter.project_status ||
+							fullProjectData?.status ||
+							fullProjectData?.customFields?.Status?.value ||
+							"No Status",
+					);
 
 					const item: KanbanItem = {
 						...frontmatter,
@@ -568,15 +647,15 @@ export class GitHubKanbanView extends ItemView {
 						title: frontmatter.title as string | undefined,
 						state: frontmatter.state as string | undefined,
 						url: frontmatter.url as string | undefined,
-						labels: (fullProjectData?.labels ||
-							frontmatter.labels ||
-							[]) as KanbanItem["labels"],
+						labels: this.normalizeLabels(
+							fullProjectData?.labels || frontmatter.labels,
+						),
 						body: fullProjectData?.body || "",
 						author: String(
 							fullProjectData?.author ||
-							frontmatter.opened_by ||
-							frontmatter.author ||
-							"unknown"
+								frontmatter.opened_by ||
+								frontmatter.author ||
+								"unknown",
 						),
 						pull_request: frontmatter.type === "pr",
 						projectTitle: project.title,
@@ -603,12 +682,44 @@ export class GitHubKanbanView extends ItemView {
 			const frontmatter = match[1];
 			const lines = frontmatter.split("\n");
 			const result: Record<string, unknown> = {};
+			// Tracks an open "projectData:" block so its indented "- projectId:"
+			// entries are collected into a real array instead of ending up as a
+			// bogus "- projectId" key. Scoped to that one key on purpose: a
+			// generic rule would turn empty scalars like "milestone:" into arrays.
+			let listEntries: Array<Record<string, string>> | null = null;
 
 			for (const line of lines) {
+				const trimmed = line.trim();
+
+				if (
+					listEntries &&
+					/^\s/.test(line) &&
+					trimmed.startsWith("- ")
+				) {
+					const entry = trimmed.substring(2);
+					const entryColon = entry.indexOf(":");
+					if (entryColon > 0) {
+						listEntries.push({
+							[entry.substring(0, entryColon).trim()]:
+								this.stripQuotes(
+									entry.substring(entryColon + 1).trim(),
+								),
+						});
+					}
+					continue;
+				}
+				listEntries = null;
+
 				const colonIndex = line.indexOf(":");
 				if (colonIndex > 0) {
 					const key = line.substring(0, colonIndex).trim();
-					let value = line.substring(colonIndex + 1).trim();
+					const value = line.substring(colonIndex + 1).trim();
+
+					if (key === "projectData" && value === "") {
+						listEntries = [];
+						result[key] = listEntries;
+						continue;
+					}
 
 					// Try to parse as JSON if it looks like an array/object
 					if (value.startsWith("[") || value.startsWith("{")) {
@@ -618,14 +729,7 @@ export class GitHubKanbanView extends ItemView {
 							result[key] = value;
 						}
 					} else {
-						// Strip surrounding quotes from string values
-						if (
-							(value.startsWith('"') && value.endsWith('"')) ||
-							(value.startsWith("'") && value.endsWith("'"))
-						) {
-							value = value.slice(1, -1);
-						}
-						result[key] = value;
+						result[key] = this.stripQuotes(value);
 					}
 				}
 			}
@@ -635,6 +739,17 @@ export class GitHubKanbanView extends ItemView {
 			console.error("Error parsing frontmatter:", error);
 			return null;
 		}
+	}
+
+	/** Strip surrounding quotes from a frontmatter string value. */
+	private stripQuotes(value: string): string {
+		if (
+			(value.startsWith('"') && value.endsWith('"')) ||
+			(value.startsWith("'") && value.endsWith("'"))
+		) {
+			return value.slice(1, -1);
+		}
+		return value;
 	}
 
 	private groupItemsByStatus(items: KanbanItem[]): Map<string, KanbanItem[]> {
@@ -759,23 +874,11 @@ export class GitHubKanbanView extends ItemView {
 	}
 
 	private async openItemFile(item: KanbanItem): Promise<void> {
-		const files = this.app.vault.getMarkdownFiles();
-
-		// First try: match by URL (most accurate)
-		if (item.url) {
-			for (const file of files) {
-				try {
-					const content = await this.app.vault.read(file);
-					const fm = this.parseFrontmatter(content);
-					if (!fm) continue;
-					if (fm.url && fm.url === item.url) {
-						await this.app.workspace.getLeaf().openFile(file);
-						return;
-					}
-				} catch {
-					// ignore
-				}
-			}
+		// The card knows which note it was built from, so two boards holding
+		// the same issue each open their own note
+		if (item.file instanceof TFile) {
+			await this.app.workspace.getLeaf().openFile(item.file);
+			return;
 		}
 
 		// Fallback: open GitHub URL if available

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import {
 	getEffectiveRepoSettings,
 	stripProfileFieldsFromRepo,
 } from "./util/settingsUtils";
+import { parseRepository } from "./util/repo-path";
 
 export default class IssueTrackerPlugin extends Plugin {
 	settings: IssueTrackerSettings = DEFAULT_SETTINGS;
@@ -156,7 +157,9 @@ export default class IssueTrackerPlugin extends Plugin {
 	/**
 	 * Build ProviderExtraParams for the given repository.
 	 */
-	private getExtraParams(repo: RepositoryTracking): ProviderExtraParams | undefined {
+	private getExtraParams(
+		repo: RepositoryTracking,
+	): ProviderExtraParams | undefined {
 		const provider = this.getProviderForRepo(repo);
 		if (provider?.type === "gitlab" && repo.gitlabProjectId) {
 			return { gitlabProjectId: repo.gitlabProjectId };
@@ -180,7 +183,9 @@ export default class IssueTrackerPlugin extends Plugin {
 				if (repo.provider !== glProvider.id || repo.gitlabProjectId)
 					continue;
 
-				const [owner, repoName] = repo.repository.split("/");
+				const { owner, repo: repoName } = parseRepository(
+					repo.repository,
+				);
 				if (!owner || !repoName) continue;
 
 				const id = await (
@@ -322,7 +327,7 @@ export default class IssueTrackerPlugin extends Plugin {
 		try {
 			const effectiveRepo = getEffectiveRepoSettings(repo, this.settings);
 			this.noticeManager.info(`Syncing repository: ${repositoryName}`);
-			const [owner, repoName] = repo.repository.split("/");
+			const { owner, repo: repoName } = parseRepository(repo.repository);
 			if (!owner || !repoName) {
 				this.noticeManager.error(
 					`Invalid repository format: ${repositoryName}`,
@@ -684,7 +689,10 @@ export default class IssueTrackerPlugin extends Plugin {
 				},
 			];
 			// Clear legacy fields
-			const legacySettings = this.settings as unknown as Record<string, unknown>;
+			const legacySettings = this.settings as unknown as Record<
+				string,
+				unknown
+			>;
 			delete legacySettings.githubToken;
 			delete legacySettings.useSecretStorage;
 			delete legacySettings.secretTokenName;
@@ -784,7 +792,10 @@ export default class IssueTrackerPlugin extends Plugin {
 						repo,
 					);
 
-					const legacyRepo = repo as unknown as Record<string, unknown>;
+					const legacyRepo = repo as unknown as Record<
+						string,
+						unknown
+					>;
 					if (legacyRepo.ignoreGlobalSettings) {
 						// Repo had custom settings - create a dedicated profile
 						const customProfileId = `migrated-${repo.repository.replace(/\//g, "-")}-${Date.now()}`;
@@ -823,7 +834,8 @@ export default class IssueTrackerPlugin extends Plugin {
 					}
 
 					// Clean up deprecated field
-					delete (merged as unknown as Record<string, unknown>).ignoreGlobalSettings;
+					delete (merged as unknown as Record<string, unknown>)
+						.ignoreGlobalSettings;
 
 					return merged;
 				},
@@ -1049,13 +1061,15 @@ export default class IssueTrackerPlugin extends Plugin {
 							profile.trackIssues === undefined &&
 							lrTrack.trackIssues !== undefined
 						) {
-							profile.trackIssues = lrTrack.trackIssues as boolean;
+							profile.trackIssues =
+								lrTrack.trackIssues as boolean;
 						}
 						if (
 							profile.trackPullRequest === undefined &&
 							lrTrack.trackPullRequest !== undefined
 						) {
-							profile.trackPullRequest = lrTrack.trackPullRequest as boolean;
+							profile.trackPullRequest =
+								lrTrack.trackPullRequest as boolean;
 						}
 					}
 				}
@@ -1186,7 +1200,9 @@ export default class IssueTrackerPlugin extends Plugin {
 	private async fetchIssues() {
 		try {
 			for (const repo of this.settings.repositories) {
-				const [owner, repoName] = repo.repository.split("/");
+				const { owner, repo: repoName } = parseRepository(
+					repo.repository,
+				);
 				if (!owner || !repoName) continue;
 
 				const provider = this.getProviderForRepo(repo);
@@ -1264,7 +1280,9 @@ export default class IssueTrackerPlugin extends Plugin {
 	private async fetchPullRequests() {
 		try {
 			for (const repo of this.settings.repositories) {
-				const [owner, repoName] = repo.repository.split("/");
+				const { owner, repo: repoName } = parseRepository(
+					repo.repository,
+				);
 				if (!owner || !repoName) continue;
 
 				const provider = this.getProviderForRepo(repo);

--- a/src/pr-file-manager.ts
+++ b/src/pr-file-manager.ts
@@ -9,6 +9,11 @@ import {
 	processFilenameTemplate,
 } from "./util/templateUtils";
 import { getEffectiveRepoSettings } from "./util/settingsUtils";
+import {
+	parseRepository,
+	sanitizeFolderSegment,
+	sanitizeOwnerPath,
+} from "./util/repo-path";
 import { extractPersistBlocks, mergePersistBlocks } from "./util/persistUtils";
 import { shouldUpdateContent, hasStatusChanged } from "./util/contentUtils";
 import { FileHelpers } from "./util/file-helpers";
@@ -46,11 +51,13 @@ export class PullRequestFileManager {
 		// Apply global defaults to repository settings
 		const effectiveRepo = getEffectiveRepoSettings(repo, this.settings);
 
-		const [owner, repoName] = effectiveRepo.repository.split("/");
+		const { owner, repo: repoName } = parseRepository(
+			effectiveRepo.repository,
+		);
 		if (!owner || !repoName) return;
 
-		const repoCleaned = repoName.replace(/\//g, "-");
-		const ownerCleaned = owner.replace(/\//g, "-");
+		const repoCleaned = sanitizeFolderSegment(repoName);
+		const ownerCleaned = sanitizeOwnerPath(owner);
 
 		await this.cleanupManager.cleanupDeletedPullRequests(
 			effectiveRepo,
@@ -91,28 +98,10 @@ export class PullRequestFileManager {
 				repoCleaned,
 			);
 
-		// Ensure folder structure exists
-		if (
-			repo.useCustomPullRequestFolder &&
-			repo.customPullRequestFolder &&
-			repo.customPullRequestFolder.trim()
-		) {
-			// For custom folders, just ensure the custom path exists
-			await this.fileHelpers.ensureFolderExists(
-				repo.customPullRequestFolder.trim(),
-			);
-		} else {
-			// For default structure, ensure nested path exists
-			const pullRequestFolder =
-				repo.pullRequestFolder ?? "GitHub Pull Requests";
-			await this.fileHelpers.ensureFolderExists(pullRequestFolder);
-			await this.fileHelpers.ensureFolderExists(
-				`${pullRequestFolder}/${ownerCleaned}`,
-			);
-			await this.fileHelpers.ensureFolderExists(
-				`${pullRequestFolder}/${ownerCleaned}/${repoCleaned}`,
-			);
-		}
+		// Ensure folder structure exists. createFolder creates nested paths
+		// recursively, so a single call covers custom and default (owner may
+		// itself be a nested GitLab group path).
+		await this.fileHelpers.ensureFolderExists(pullRequestFolderPath);
 
 		// Normalize folder path to use forward slashes for consistent vault lookups
 		const normalizedPullRequestFolderPath = pullRequestFolderPath.replace(
@@ -123,7 +112,7 @@ export class PullRequestFileManager {
 			`${normalizedPullRequestFolderPath}/${fileName}`,
 		);
 
-		const [owner, repoName] = repo.repository.split("/");
+		const { owner, repo: repoName } = parseRepository(repo.repository);
 		const extra: ProviderExtraParams | undefined = repo.gitlabProjectId
 			? { gitlabProjectId: repo.gitlabProjectId }
 			: undefined;
@@ -170,7 +159,10 @@ export class PullRequestFileManager {
 					// Check if content needs updating based on updated_at field
 					if (
 						!statusHasChanged &&
-						!shouldUpdateContent(existingContent, pr.updated_at ?? "")
+						!shouldUpdateContent(
+							existingContent,
+							pr.updated_at ?? "",
+						)
 					) {
 						this.noticeManager.debug(
 							`Skipped update for PR ${pr.number}: no changes detected (updated_at match)`,

--- a/src/providers/gitlab/gitlab-provider.ts
+++ b/src/providers/gitlab/gitlab-provider.ts
@@ -14,6 +14,7 @@ import {
 	PullRequest,
 	RepositoryRef,
 } from "../domain";
+import { parseRepository } from "../../util/repo-path";
 
 // --- Raw GitLab REST shapes (only the fields this provider reads) ---
 
@@ -561,9 +562,11 @@ export class GitLabProvider implements IssueProvider {
 			);
 
 			return projects.map((p) => {
-				const parts = p.path_with_namespace.split("/");
-				const name = parts[parts.length - 1];
-				const ownerPath = parts.slice(0, -1).join("/");
+				// Groups can be nested, so the namespace is everything before
+				// the last slash (e.g. "GroupA/subGroupB" for "GroupA/subGroupB/repo").
+				const { owner: ownerPath, repo: name } = parseRepository(
+					p.path_with_namespace,
+				);
 				return {
 					owner: { login: ownerPath },
 					name,
@@ -721,8 +724,7 @@ export class GitLabProvider implements IssueProvider {
 			return null;
 
 		const widgets = childResponse.json?.data?.workItem?.widgets as
-			| GitLabWorkItemWidget[]
-			| undefined;
+			GitLabWorkItemWidget[] | undefined;
 		if (!widgets) return null;
 
 		const hierarchyWidget = widgets.find((w) => w.children !== undefined);
@@ -882,13 +884,11 @@ export class GitLabProvider implements IssueProvider {
 		if (parentResponse.status < 200 || parentResponse.status >= 300)
 			return undefined;
 
-		const widgets = parentResponse.json?.data?.workItem
-			?.widgets as GitLabWorkItemWidget[] | undefined;
+		const widgets = parentResponse.json?.data?.workItem?.widgets as
+			GitLabWorkItemWidget[] | undefined;
 		if (!widgets) return undefined;
 
-		const hierarchyWidget = widgets.find(
-			(w) => w.parent !== undefined,
-		);
+		const hierarchyWidget = widgets.find((w) => w.parent !== undefined);
 		if (!hierarchyWidget?.parent) return null;
 
 		const p = hierarchyWidget.parent;

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -7,7 +7,12 @@ import {
 	setIcon,
 	SecretComponent,
 } from "obsidian";
-import { ProviderConfig, ProviderId, ProviderType, ProjectStatusOption } from "./types";
+import {
+	ProviderConfig,
+	ProviderId,
+	ProviderType,
+	ProjectStatusOption,
+} from "./types";
 import { RepositoryRef } from "./providers/domain";
 import IssueTrackerPlugin from "./main";
 import { RepositoryRenderer } from "./settings/repository-renderer";
@@ -21,6 +26,7 @@ import {
 	getRepositoryProfiles,
 	getProjectProfiles,
 } from "./util/settingsUtils";
+import { parseRepository } from "./util/repo-path";
 
 export class IssueTrackerSettingTab extends PluginSettingTab {
 	private selectedRepositories: Set<string> = new Set();
@@ -337,10 +343,7 @@ export class IssueTrackerSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.syncNoticeMode)
 					.onChange(async (value) => {
 						this.plugin.settings.syncNoticeMode = value as
-							| "minimal"
-							| "normal"
-							| "extensive"
-							| "debug";
+							"minimal" | "normal" | "extensive" | "debug";
 						await this.plugin.saveSettings();
 					});
 			});
@@ -422,10 +425,7 @@ export class IssueTrackerSettingTab extends PluginSettingTab {
 							return;
 						}
 						this.plugin.settings.escapeMode = value as
-							| "disabled"
-							| "normal"
-							| "strict"
-							| "veryStrict";
+							"disabled" | "normal" | "strict" | "veryStrict";
 						await this.plugin.saveSettings();
 					}),
 			);
@@ -2608,7 +2608,7 @@ export class IssueTrackerSettingTab extends PluginSettingTab {
 		let reposFailed = 0;
 
 		for (const repo of this.plugin.settings.repositories) {
-			const [owner, repoName] = repo.repository.split("/");
+			const { owner, repo: repoName } = parseRepository(repo.repository);
 			if (!owner || !repoName) continue;
 			reposAttempted++;
 

--- a/src/settings/modal-manager.ts
+++ b/src/settings/modal-manager.ts
@@ -2,6 +2,7 @@ import { App, Modal, Notice, setIcon } from "obsidian";
 import { RepositoryTracking } from "../types";
 import IssueTrackerPlugin from "../main";
 import { UIHelpers } from "./ui-helpers";
+import { parseRepository } from "../util/repo-path";
 
 export class ModalManager {
 	constructor(
@@ -167,7 +168,7 @@ export class ModalManager {
 			return;
 		}
 
-		const [owner, repoName] = repositoryName.split("/");
+		const { owner, repo: repoName } = parseRepository(repositoryName);
 		if (!owner || !repoName) {
 			new Notice("Invalid repository format. Expected 'owner/repo'.");
 			return;
@@ -277,9 +278,7 @@ export class ModalManager {
 		repositoryName: string,
 		repo: RepositoryTracking,
 		filterType:
-			| "assigneeFilters"
-			| "prAssigneeFilters"
-			| "prReviewerFilters",
+			"assigneeFilters" | "prAssigneeFilters" | "prReviewerFilters",
 		textAreaElement: HTMLTextAreaElement,
 	): Promise<void> {
 		const github = this.plugin.providerRegistry.get("github");
@@ -290,7 +289,7 @@ export class ModalManager {
 			return;
 		}
 
-		const [owner, repoName] = repositoryName.split("/");
+		const { owner, repo: repoName } = parseRepository(repositoryName);
 		if (!owner || !repoName) {
 			new Notice("Invalid repository format. Expected 'owner/repo'.");
 			return;

--- a/src/settings/repository-list-manager.ts
+++ b/src/settings/repository-list-manager.ts
@@ -7,6 +7,7 @@ import {
 } from "../types";
 import IssueTrackerPlugin from "../main";
 import { getRepositoryProfiles } from "../util/settingsUtils";
+import { parseRepository } from "../util/repo-path";
 
 export class RepositoryListManager {
 	private selectedRepositories: Set<string> = new Set();
@@ -235,7 +236,7 @@ export class RepositoryListManager {
 		> = {};
 
 		for (const repo of this.plugin.settings.repositories) {
-			const [owner, repoName] = repo.repository.split("/");
+			const { owner, repo: repoName } = parseRepository(repo.repository);
 			if (!owner || !repoName) continue;
 
 			if (!reposByOwner[owner]) {
@@ -331,13 +332,13 @@ export class RepositoryListManager {
 			});
 
 			const sortedRepos = reposByOwner[owner].repos.sort((a, b) => {
-				const aName = a.repository.split("/")[1] || "";
-				const bName = b.repository.split("/")[1] || "";
+				const aName = parseRepository(a.repository).repo;
+				const bName = parseRepository(b.repository).repo;
 				return aName.localeCompare(bName);
 			});
 
 			for (const repo of sortedRepos) {
-				const repoName = repo.repository.split("/")[1] || "";
+				const repoName = parseRepository(repo.repository).repo;
 
 				const repoItem = reposContainer.createDiv(
 					"github-issues-item github-issues-repo-settings",

--- a/src/util/file-helpers.ts
+++ b/src/util/file-helpers.ts
@@ -53,11 +53,22 @@ export class FileHelpers {
 
 		// Normalize path separators to forward slashes for consistency
 		const normalizedPath = path.replace(/\\/g, "/");
-		let existing = this.app.vault.getAbstractFileByPath(normalizedPath);
+		const existing = this.app.vault.getAbstractFileByPath(normalizedPath);
 
 		// Check if folder already exists
 		if (existing instanceof TFolder) {
 			return;
+		}
+
+		// Ensure parent folders exist first. Not every Obsidian version creates
+		// intermediate folders for createFolder, and repository owners may be
+		// nested group paths (e.g. GitLab `intern/brotherhoodrp/polas`).
+		const parentPath = normalizedPath.substring(
+			0,
+			normalizedPath.lastIndexOf("/"),
+		);
+		if (parentPath && parentPath !== normalizedPath) {
+			await this.ensureFolderExists(parentPath);
 		}
 
 		try {

--- a/src/util/repo-path.ts
+++ b/src/util/repo-path.ts
@@ -1,0 +1,44 @@
+/**
+ * Helpers for parsing repository identifiers of the form `owner/repo`.
+ *
+ * GitLab projects can live under nested groups, so the identifier may contain
+ * more than one slash (e.g. `intern/brotherhoodrp/polas`). A naive
+ * `const [owner, repo] = id.split("/")` drops every segment after the second.
+ * These helpers split on the *last* slash so nested namespaces are preserved
+ * while still working for GitHub's plain `owner/repo`.
+ */
+
+/**
+ * Split a repository identifier into its owner path and repo name.
+ * The owner is everything before the last slash, the repo is the last segment.
+ */
+export function parseRepository(repository: string): {
+	owner: string;
+	repo: string;
+} {
+	const idx = repository.lastIndexOf("/");
+	if (idx < 0) return { owner: "", repo: repository };
+	return { owner: repository.slice(0, idx), repo: repository.slice(idx + 1) };
+}
+
+/**
+ * Sanitize a single path segment by stripping filesystem-unsafe characters.
+ */
+export function sanitizeFolderSegment(seg: string): string {
+	return seg
+		.replace(/[<>:"|?*\\]/g, "-")
+		.replace(/\.\./g, ".")
+		.trim();
+}
+
+/**
+ * Sanitize an owner path segment-by-segment, keeping "/" as a folder separator
+ * so nested GitLab groups map onto nested folders.
+ */
+export function sanitizeOwnerPath(owner: string): string {
+	return owner
+		.split("/")
+		.map(sanitizeFolderSegment)
+		.filter(Boolean)
+		.join("/");
+}

--- a/src/util/templateUtils.ts
+++ b/src/util/templateUtils.ts
@@ -1,11 +1,8 @@
 import { format } from "date-fns";
 import { escapeBody, escapeYamlString } from "./escapeUtils";
+import { parseRepository } from "./repo-path";
 import { ProjectData } from "../types";
-import {
-	Issue,
-	IssueComment,
-	PullRequest,
-} from "../providers/domain";
+import { Issue, IssueComment, PullRequest } from "../providers/domain";
 
 interface SubIssueData {
 	number: number;
@@ -251,6 +248,7 @@ function buildReplacements(
 	if (data.projectData && data.projectData.length > 0) {
 		const firstProject = data.projectData[0];
 		replacements["{project}"] = firstProject.projectTitle || "";
+		replacements["{project_id}"] = firstProject.projectId || "";
 		replacements["{project_url}"] = firstProject.projectUrl || "";
 		replacements["{project_number}"] =
 			firstProject.projectNumber?.toString() || "";
@@ -284,6 +282,7 @@ function buildReplacements(
 			: "";
 	} else {
 		replacements["{project}"] = "";
+		replacements["{project_id}"] = "";
 		replacements["{project_url}"] = "";
 		replacements["{project_number}"] = "";
 		replacements["{project_status}"] = "";
@@ -656,6 +655,10 @@ function getVariableValue(
 			return data.projectData && data.projectData.length > 0
 				? data.projectData[0].projectTitle
 				: undefined;
+		case "project_id":
+			return data.projectData && data.projectData.length > 0
+				? data.projectData[0].projectId
+				: undefined;
 		case "project_status":
 			return data.projectData && data.projectData.length > 0
 				? data.projectData[0].status
@@ -718,7 +721,7 @@ export function createIssueTemplateData(
 	subIssues?: Issue[],
 	parentIssue?: Issue | null,
 ): TemplateData {
-	const [owner, repoName] = repository.split("/");
+	const { owner, repo: repoName } = parseRepository(repository);
 
 	const milestoneTitle =
 		issue.milestone?.title || issue.milestone?.name || "";
@@ -795,7 +798,7 @@ export function createPullRequestTemplateData(
 	escapeHashTags: boolean = false,
 	projectData?: ProjectData[],
 ): TemplateData {
-	const [owner, repoName] = repository.split("/");
+	const { owner, repo: repoName } = parseRepository(repository);
 
 	const milestoneTitle = pr.milestone?.title || pr.milestone?.name || "";
 


### PR DESCRIPTION
[Custom content templates](https://github.com/LonoxX/obsidian-github-issues/wiki/Project-Settings#project-template-variables) should add `project_id: "{project_id}"` without it the fallback is folder and project title. 

Repository identifiers were split on the first slash, so nested GitLab groups lost every segment after the second. Splitting now happens on the last slash.

Closes #57 
Closes #58 
